### PR TITLE
Update theme styling for login and dashboard

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,12 +1,14 @@
 :root {
   color-scheme: dark;
-  --bg-start: #0b0e1a;
-  --bg-end: #11192b;
-  --fg: #f2f4ff;
-  --accent: #6c7bff;
-  --accent-strong: #9aa6ff;
-  --card-bg: rgba(21, 29, 47, 0.55);
-  --card-border: rgba(162, 175, 255, 0.18);
+  --bg-start: #1d1345;
+  --bg-mid: #120a31;
+  --bg-end: #04000e;
+  --fg: #f3f2ff;
+  --muted: rgba(226, 220, 255, 0.72);
+  --accent: #5f4bd9;
+  --accent-strong: #7b63ff;
+  --card-bg: rgba(255, 255, 255, 0.05);
+  --card-border: rgba(222, 210, 255, 0.14);
   --error: #ff6c6c;
 }
 
@@ -22,11 +24,12 @@ body {
 body {
   margin: 0;
   font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
-  background: radial-gradient(circle at top, rgba(41, 52, 92, 0.6), transparent 55%),
-    radial-gradient(circle at bottom, rgba(23, 35, 64, 0.8), transparent 60%),
-    linear-gradient(160deg, var(--bg-start), var(--bg-end));
+  font-size: 0.94rem;
+  background: radial-gradient(circle at 20% -10%, rgba(117, 73, 217, 0.18), transparent 60%),
+    radial-gradient(circle at 80% 110%, rgba(87, 32, 145, 0.2), transparent 60%),
+    linear-gradient(145deg, var(--bg-start) 0%, var(--bg-mid) 52%, var(--bg-end) 100%);
   color: var(--fg);
-  line-height: 1.6;
+  line-height: 1.7;
 }
 
 .page-shell {
@@ -47,61 +50,63 @@ body {
   height: 100%;
   pointer-events: none;
   z-index: 0;
-  opacity: 0.75;
+  opacity: 0.8;
 }
 
 .glass-card {
   position: relative;
   z-index: 1;
-  width: min(420px, 100%);
-  padding: 2.75rem 2.5rem;
+  width: min(520px, 92vw);
+  padding: clamp(1.6rem, 4vw, 2rem) clamp(1.5rem, 4vw, 2.3rem);
   background: var(--card-bg);
   border: 1px solid var(--card-border);
-  border-radius: 22px;
+  border-radius: 18px;
   backdrop-filter: blur(22px);
-  box-shadow: 0 24px 60px rgba(6, 11, 22, 0.45);
+  box-shadow: 0 28px 70px rgba(8, 2, 25, 0.55);
   animation: fadeIn 260ms ease-out both;
 }
 
 .glass-card h1 {
-  margin: 0 0 1.5rem;
-  font-size: clamp(1.75rem, 2vw + 1rem, 2.3rem);
-  letter-spacing: 0.4px;
+  margin: 0 0 1.3rem;
+  font-size: clamp(1.9rem, 2vw + 1.05rem, 2.15rem);
+  letter-spacing: 0.2px;
 }
 
 .form-group {
   display: flex;
   flex-direction: column;
-  gap: 0.6rem;
-  margin-bottom: 1.5rem;
+  gap: 0.45rem;
+  margin-bottom: 1.1rem;
 }
 
 label {
+  font-size: 0.82rem;
   font-weight: 600;
-  letter-spacing: 0.3px;
+  letter-spacing: 0.25px;
 }
 
 input[type="text"],
 input[type="password"] {
   width: 100%;
-  padding: 0.85rem 1rem;
-  border-radius: 12px;
-  border: 1px solid rgba(160, 173, 255, 0.35);
-  background: rgba(9, 13, 24, 0.65);
+  padding: 0.65rem 0.9rem;
+  border-radius: 10px;
+  border: 1px solid rgba(210, 198, 255, 0.28);
+  background: rgba(15, 10, 32, 0.55);
   color: var(--fg);
-  font-size: 1rem;
-  transition: border-color 180ms ease, box-shadow 180ms ease;
+  font-size: 0.95rem;
+  transition: border-color 180ms ease, box-shadow 180ms ease, background 180ms ease;
 }
 
 input[type="text"]::placeholder,
 input[type="password"]::placeholder {
-  color: rgba(235, 237, 255, 0.45);
+  color: rgba(229, 222, 255, 0.42);
 }
 
 input[type="text"]:focus,
 input[type="password"]:focus {
-  border-color: var(--accent);
-  box-shadow: 0 0 0 3px rgba(120, 140, 255, 0.25);
+  border-color: rgba(143, 123, 255, 0.75);
+  box-shadow: 0 0 0 3px rgba(116, 90, 255, 0.18);
+  background: rgba(24, 16, 53, 0.65);
   outline: none;
 }
 
@@ -113,20 +118,21 @@ button {
 
 .primary-button {
   width: 100%;
-  padding: 0.9rem 1rem;
+  padding: 0.75rem 1rem;
   border: none;
-  border-radius: 12px;
-  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
-  color: #0b0f1d;
-  font-size: 1.05rem;
-  font-weight: 700;
-  letter-spacing: 0.3px;
-  transition: transform 160ms ease, box-shadow 160ms ease;
+  border-radius: 10px;
+  background: linear-gradient(135deg, #3a2072, #2b1b92);
+  color: #f9f8ff;
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+  transition: transform 160ms ease, box-shadow 160ms ease, filter 160ms ease;
 }
 
 .primary-button:hover {
   transform: translateY(-1px);
-  box-shadow: 0 18px 35px rgba(76, 91, 207, 0.3);
+  box-shadow: 0 16px 36px rgba(35, 20, 90, 0.45);
+  filter: brightness(1.08);
 }
 
 .primary-button:active {
@@ -143,7 +149,7 @@ button {
 .error-message {
   margin-top: 0.5rem;
   color: var(--error);
-  font-size: 0.95rem;
+  font-size: 0.9rem;
 }
 
 .logout-button {
@@ -151,19 +157,20 @@ button {
   top: 1.5rem;
   right: 1.75rem;
   z-index: 2;
-  padding: 0.6rem 1.2rem;
+  padding: 0.55rem 1.15rem;
   border-radius: 999px;
-  background: rgba(16, 24, 42, 0.6);
-  border: 1px solid rgba(156, 168, 255, 0.35);
+  background: rgba(35, 20, 76, 0.6);
+  border: 1px solid rgba(190, 158, 255, 0.28);
   color: var(--fg);
+  font-size: 0.9rem;
   font-weight: 600;
   transition: background 180ms ease, border-color 180ms ease,
     transform 180ms ease;
 }
 
 .logout-button:hover {
-  background: rgba(24, 32, 56, 0.7);
-  border-color: rgba(156, 168, 255, 0.65);
+  background: rgba(45, 30, 95, 0.72);
+  border-color: rgba(190, 158, 255, 0.55);
   transform: translateY(-1px);
 }
 
@@ -174,26 +181,26 @@ button {
 .greeting-wrapper {
   position: relative;
   z-index: 1;
-  max-width: min(680px, 90vw);
+  max-width: min(640px, 92vw);
   text-align: center;
   animation: fadeIn 240ms ease-out both;
 }
 
 .greeting-wrapper h1 {
   margin: 0;
-  font-size: clamp(1.9rem, 3vw + 1rem, 3.4rem);
-  font-weight: 700;
-  letter-spacing: 0.4px;
+  font-size: clamp(1.8rem, 2.5vw + 1rem, 2.8rem);
+  font-weight: 600;
+  letter-spacing: 0.3px;
 }
 
 .greeting-wrapper p {
   margin-top: 1rem;
-  font-size: clamp(1rem, 1vw + 0.8rem, 1.3rem);
-  color: rgba(235, 239, 255, 0.75);
+  font-size: clamp(0.95rem, 0.8vw + 0.75rem, 1.1rem);
+  color: var(--muted);
 }
 
 :focus-visible {
-  outline: 3px solid rgba(118, 140, 254, 0.7);
+  outline: 3px solid rgba(119, 90, 255, 0.65);
   outline-offset: 3px;
 }
 
@@ -210,12 +217,12 @@ button {
 
 @media (max-width: 600px) {
   .glass-card {
-    padding: 2.2rem 1.75rem;
+    padding: 1.6rem 1.5rem;
   }
 
   .logout-button {
     top: 1rem;
     right: 1rem;
-    padding: 0.5rem 1rem;
+    padding: 0.48rem 0.95rem;
   }
 }

--- a/src/components/ParticleBackground.jsx
+++ b/src/components/ParticleBackground.jsx
@@ -3,16 +3,28 @@
 import { useEffect, useRef } from "react";
 
 const MAX_PARTICLES = 120;
+const MIN_PARTICLES = 80;
+
+const COLOR_PALETTE = [
+  { r: 206, g: 180, b: 255 }, // lavender
+  { r: 148, g: 247, b: 255 }, // cyan / mint
+  { r: 255, g: 153, b: 233 }, // magenta
+  { r: 255, g: 219, b: 173 }, // pale gold
+];
 
 function createParticles(count, width, height) {
-  return Array.from({ length: count }, () => ({
-    x: Math.random() * width,
-    y: Math.random() * height,
-    size: Math.random() * 1.8 + 0.6,
-    velocityX: (Math.random() - 0.5) * 0.22,
-    velocityY: (Math.random() - 0.5) * 0.22,
-    alpha: Math.random() * 0.35 + 0.1,
-  }));
+  return Array.from({ length: count }, () => {
+    const color = COLOR_PALETTE[Math.floor(Math.random() * COLOR_PALETTE.length)];
+    return {
+      x: Math.random() * width,
+      y: Math.random() * height,
+      size: Math.random() * 1.5 + 1,
+      velocityX: (Math.random() - 0.5) * 0.12,
+      velocityY: (Math.random() - 0.5) * 0.12,
+      alpha: Math.random() * 0.25 + 0.08,
+      color,
+    };
+  });
 }
 
 export default function ParticleBackground() {
@@ -37,9 +49,10 @@ export default function ParticleBackground() {
       context.setTransform(1, 0, 0, 1, 0, 0);
       context.scale(ratio, ratio);
 
-      const targetCount = Math.min(
-        MAX_PARTICLES,
-        Math.max(30, Math.floor((innerWidth + innerHeight) / 18)),
+      const estimatedCount = Math.floor((innerWidth + innerHeight) / 22);
+      const targetCount = Math.max(
+        MIN_PARTICLES,
+        Math.min(MAX_PARTICLES, estimatedCount),
       );
 
       if (particlesRef.current.length !== targetCount) {
@@ -68,11 +81,18 @@ export default function ParticleBackground() {
         if (particle.y < -10) particle.y = height + 10;
         if (particle.y > height + 10) particle.y = -10;
 
+        const { r, g, b } = particle.color;
+        const fill = `rgba(${r}, ${g}, ${b}, ${particle.alpha})`;
         context.beginPath();
+        context.shadowColor = `rgba(${r}, ${g}, ${b}, ${particle.alpha * 1.6})`;
+        context.shadowBlur = 12;
+        context.fillStyle = fill;
         context.arc(particle.x, particle.y, particle.size, 0, Math.PI * 2);
-        context.fillStyle = `rgba(176, 186, 255, ${particle.alpha})`;
         context.fill();
       });
+
+      context.shadowBlur = 0;
+      context.shadowColor = "transparent";
 
       frameRef.current = requestAnimationFrame(step);
     }


### PR DESCRIPTION
## Summary
- replace the existing blue visuals with a dark purple gradient theme and refined typography across login and dashboard views
- adjust the glass login card, inputs, and primary actions to match the slimmer proportions requested
- refresh the particle background with a colorful pastel palette, gentle glow, and consistent population behind both pages

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbd894a9a0832c988587c10d37a0eb