### PR TITLE
Add shared live timestamp overlay

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -32,6 +32,27 @@ body {
   line-height: 1.7;
 }
 
+.live-timestamp {
+  position: fixed;
+  bottom: 1.15rem;
+  right: 1.15rem;
+  z-index: 1;
+  padding: 0.3rem 0.65rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(10, 8, 26, 0.35);
+  color: rgba(255, 255, 255, 0.66);
+  font-family: "JetBrains Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.02em;
+  line-height: 1;
+  pointer-events: none;
+  user-select: none;
+  font-variant-numeric: tabular-nums;
+  backdrop-filter: blur(14px);
+  box-shadow: 0 12px 24px rgba(4, 0, 14, 0.18);
+}
+
 .page-shell {
   position: relative;
   min-height: 100vh;

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,5 +1,7 @@
 import "./globals.css";
 
+import LiveTimestamp from "@/components/LiveTimestamp";
+
 export const metadata = {
   title: "CVNS Dashboard",
   description: "Secure client-side demo login and dashboard experience.",
@@ -8,7 +10,10 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        {children}
+        <LiveTimestamp />
+      </body>
     </html>
   );
 }

--- a/src/components/LiveTimestamp.jsx
+++ b/src/components/LiveTimestamp.jsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const formatTimestamp = (date) => {
+  const pad = (value) => String(value).padStart(2, "0");
+  const day = pad(date.getDate());
+  const month = pad(date.getMonth() + 1);
+  const year = date.getFullYear();
+  const hours = pad(date.getHours());
+  const minutes = pad(date.getMinutes());
+  const seconds = pad(date.getSeconds());
+
+  return `${day}/${month}/${year} ${hours}:${minutes}:${seconds}`;
+};
+
+export default function LiveTimestamp() {
+  const [now, setNow] = useState(() => new Date());
+
+  useEffect(() => {
+    const updateTimestamp = () => setNow(new Date());
+    updateTimestamp();
+    const intervalId = window.setInterval(updateTimestamp, 1_000);
+
+    return () => window.clearInterval(intervalId);
+  }, []);
+
+  return (
+    <time
+      className="live-timestamp"
+      suppressHydrationWarning
+      dateTime={now.toISOString()}
+      aria-live="off"
+    >
+      {formatTimestamp(now)}
+    </time>
+  );
+}


### PR DESCRIPTION
## Summary
- add a client-side LiveTimestamp component that renders the local time in DD/MM/YYYY HH:MM:SS format and refreshes every second
- include the timestamp overlay in the root layout so it appears across the login and dashboard pages
- style the overlay as a subtle fixed pill with monospace numerals, light tint, and pointer-events disabled so it sits unobtrusively above the particle canvas

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbe0282698832c9887c3aa2f461df4