### PR TITLE
Add dashboard quick action button row

### DIFF
--- a/src/app/dashboard/page.js
+++ b/src/app/dashboard/page.js
@@ -7,6 +7,107 @@ import ParticleBackground from "@/components/ParticleBackground";
 import { LOGIN_FLAG_KEY, USERNAME_KEY } from "@/utils/auth";
 import { getGreetingForDate } from "@/utils/time";
 
+const iconProps = {
+  xmlns: "http://www.w3.org/2000/svg",
+  viewBox: "0 0 24 24",
+  fill: "none",
+  stroke: "currentColor",
+  strokeWidth: 1.8,
+  strokeLinecap: "round",
+  strokeLinejoin: "round",
+};
+
+function TruckIcon(props) {
+  return (
+    <svg {...iconProps} {...props}>
+      <path d="M3 16V7.5a1.5 1.5 0 0 1 1.5-1.5h8.5v6h4.3l2.2 2.2V16" />
+      <circle cx="7" cy="16.5" r="1.6" />
+      <circle cx="17" cy="16.5" r="1.6" />
+      <path d="M3 16h1.9" />
+      <path d="M12 12V6" />
+    </svg>
+  );
+}
+
+function GaugeIcon(props) {
+  return (
+    <svg {...iconProps} {...props}>
+      <path d="M5.5 18.5a8.5 8.5 0 1 1 13 0" />
+      <path d="M12 13.5l2.8-2.8" />
+      <circle cx="12" cy="13.5" r="1.2" />
+      <path d="M4.5 14.5h1.8" />
+      <path d="M17.7 9.1l1.3-1.3" />
+    </svg>
+  );
+}
+
+function PackageIcon(props) {
+  return (
+    <svg {...iconProps} {...props}>
+      <path d="M20 8.5v7.8a1.7 1.7 0 0 1-0.9 1.5l-6.3 3.1a1.7 1.7 0 0 1-1.5 0L5 17.8a1.7 1.7 0 0 1-0.9-1.5V8.5a1.7 1.7 0 0 1 0.9-1.5l6.3-3.1a1.7 1.7 0 0 1 1.5 0l6.3 3.1a1.7 1.7 0 0 1 0.9 1.5z" />
+      <path d="M3.9 7.5L12 11l8.1-3.5" />
+      <path d="M12 22V11" />
+      <path d="M9 14.5l2.4 2.4 3.6-3.6" />
+    </svg>
+  );
+}
+
+function CheatsheetIcon(props) {
+  return (
+    <svg {...iconProps} {...props}>
+      <path d="M7 3h7l4 4v12.5A1.5 1.5 0 0 1 16.5 21h-9A1.5 1.5 0 0 1 6 19.5v-14A1.5 1.5 0 0 1 7.5 4" />
+      <path d="M14 3v4h4" />
+      <path d="M8.5 12.5h7" />
+      <path d="M8.5 16h4.5" />
+      <path d="M8.5 9h3" />
+    </svg>
+  );
+}
+
+function HistoryIcon(props) {
+  return (
+    <svg {...iconProps} {...props}>
+      <path d="M4.5 13a7.5 7.5 0 1 1 2.2 5.3" />
+      <path d="M4.5 13h3.5" />
+      <path d="M12 8v5l3 2" />
+    </svg>
+  );
+}
+
+function DashboardIcon(props) {
+  return (
+    <svg {...iconProps} {...props}>
+      <rect x="3.5" y="4" width="7.5" height="6.5" rx="1.2" />
+      <rect x="13" y="4" width="7.5" height="4.8" rx="1.2" />
+      <rect x="3.5" y="12" width="7.5" height="7" rx="1.2" />
+      <rect x="13" y="10.5" width="7.5" height="8.5" rx="1.2" />
+    </svg>
+  );
+}
+
+function BarcodeIcon(props) {
+  return (
+    <svg {...iconProps} {...props}>
+      <line x1="4.5" y1="5.5" x2="4.5" y2="18.5" />
+      <line x1="7" y1="5.5" x2="7" y2="18.5" />
+      <line x1="9.5" y1="5.5" x2="9.5" y2="18.5" />
+      <line x1="12.5" y1="5.5" x2="12.5" y2="18.5" />
+      <line x1="15.5" y1="5.5" x2="15.5" y2="18.5" />
+      <line x1="18" y1="5.5" x2="18" y2="18.5" />
+    </svg>
+  );
+}
+
+const QUICK_ACTIONS = [
+  { label: "Truck Monitor", Icon: TruckIcon },
+  { label: "Productivity Monitor", Icon: GaugeIcon },
+  { label: "Delivery Monitor", Icon: PackageIcon },
+  { label: "Cheatsheet", Icon: CheatsheetIcon },
+  { label: "User History", Icon: HistoryIcon },
+  { label: "Main Dashboard", Icon: DashboardIcon },
+  { label: "Barcode Generator", Icon: BarcodeIcon },
+];
+
 export default function DashboardPage() {
   const router = useRouter();
   const [displayName, setDisplayName] = useState("User");
@@ -43,6 +144,10 @@ export default function DashboardPage() {
     router.replace("/");
   };
 
+  const handleQuickAction = (label) => {
+    console.info(`[Quick Action] ${label}`);
+  };
+
   if (!ready) {
     return (
       <div className="page-shell">
@@ -62,6 +167,21 @@ export default function DashboardPage() {
           {greeting}, {displayName}
         </h1>
         <p>Welcome to the CVNS dashboard.</p>
+        <div className="quick-actions" role="navigation" aria-label="Dashboard quick links">
+          <div className="quick-actions-track">
+            {QUICK_ACTIONS.map(({ label, Icon }) => (
+              <button
+                type="button"
+                key={label}
+                className="quick-action-button"
+                onClick={() => handleQuickAction(label)}
+              >
+                <Icon className="quick-action-icon" aria-hidden="true" focusable="false" />
+                <span>{label}</span>
+              </button>
+            ))}
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -228,6 +228,105 @@ button {
   color: var(--muted);
 }
 
+.quick-actions {
+  margin-top: clamp(1.3rem, 1.2vw + 1rem, 2rem);
+  display: flex;
+  justify-content: center;
+}
+
+.quick-actions-track {
+  display: flex;
+  gap: clamp(0.7rem, 1.5vw, 1.1rem);
+  justify-content: center;
+  align-items: stretch;
+  flex-wrap: nowrap;
+  width: min(100%, 960px);
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding: 0.35rem 0.25rem;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(136, 110, 255, 0.45) transparent;
+  -webkit-overflow-scrolling: touch;
+}
+
+.quick-actions-track::-webkit-scrollbar {
+  height: 6px;
+}
+
+.quick-actions-track::-webkit-scrollbar-thumb {
+  background: rgba(109, 88, 214, 0.45);
+  border-radius: 999px;
+}
+
+.quick-actions-track::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.quick-action-button {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.55rem;
+  padding: 0.55rem clamp(0.95rem, 1.8vw, 1.2rem);
+  min-height: 2.55rem;
+  border-radius: 999px;
+  border: 1px solid rgba(160, 132, 255, 0.42);
+  background: linear-gradient(135deg, rgba(76, 54, 166, 0.92), rgba(127, 101, 255, 0.85));
+  color: var(--fg);
+  font-size: clamp(0.78rem, 0.6vw + 0.7rem, 0.88rem);
+  font-weight: 600;
+  letter-spacing: 0.18px;
+  white-space: nowrap;
+  text-decoration: none;
+  transition: transform 160ms ease, box-shadow 160ms ease, filter 160ms ease,
+    border-color 160ms ease;
+  box-shadow: 0 14px 34px rgba(22, 6, 74, 0.46);
+}
+
+.quick-action-button:hover {
+  transform: translateY(-2px);
+  filter: brightness(1.05);
+  border-color: rgba(184, 160, 255, 0.65);
+  box-shadow: 0 18px 40px rgba(33, 12, 105, 0.5);
+}
+
+.quick-action-button:active {
+  transform: translateY(0);
+  filter: brightness(0.98);
+  box-shadow: 0 12px 30px rgba(22, 6, 74, 0.38);
+}
+
+.quick-action-button:focus-visible {
+  outline: none;
+  border-color: rgba(196, 176, 255, 0.75);
+  box-shadow:
+    0 0 0 3px rgba(123, 99, 255, 0.35),
+    0 18px 42px rgba(33, 12, 105, 0.52);
+}
+
+.quick-action-icon {
+  width: 1.05rem;
+  height: 1.05rem;
+  color: rgba(235, 228, 255, 0.9);
+  flex-shrink: 0;
+}
+
+.quick-action-button span {
+  line-height: 1.1;
+}
+
+@media (max-width: 720px) {
+  .quick-actions {
+    justify-content: flex-start;
+  }
+
+  .quick-actions-track {
+    justify-content: flex-start;
+    margin: 0 auto;
+  }
+}
+
 :focus-visible {
   outline: 3px solid rgba(119, 90, 255, 0.65);
   outline-offset: 3px;


### PR DESCRIPTION
## Summary
- add a quick-action navigation row beneath the greeting with lucide-style icons for each dashboard area
- style the buttons to match the existing neon aesthetic, keep them aligned on one row, and support horizontal scrolling on small screens

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbec25b40c832ca571e0e1004ac126