### PR TITLE
Integrate Supabase authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Copy this file to `.env.local` and provide your Supabase credentials.
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -1,36 +1,33 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+# Dashboard
 
-## Getting Started
+This project is a Next.js dashboard that now authenticates users against Supabase. The demo username/password flow has been removed in favour of real Supabase email/password authentication.
 
-First, run the development server:
+## Configuration
+
+1. Copy `.env.example` to `.env.local` in the project root:
+
+   ```bash
+   cp .env.example .env.local
+   ```
+
+2. Open `.env.local` and fill in your Supabase project credentials:
+
+   ```env
+   NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+   NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+   ```
+
+   These values correspond to the `Project URL` and the `anon` public API key from the Supabase dashboard.
+
+3. Ensure the Supabase user you created has a `display_name` (or `full_name`) set in their profile metadata. The automation in this repository cannot update Supabase user profiles directly, so this step must be completed manually within the Supabase dashboard.
+
+## Running locally
+
+Install dependencies and start the development server:
 
 ```bash
+npm install
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
-
-You can start editing the page by modifying `app/page.js`. The page auto-updates as you edit the file.
-
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+Then visit [http://localhost:3000](http://localhost:3000) and log in using any email/password combination that exists in your Supabase project's Authentication users list.

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,7 +1,4 @@
 export const LOGIN_FLAG_KEY = "cvnsLoggedIn";
 export const USERNAME_KEY = "cvnsUsername";
-
-export const DEMO_CREDENTIALS = {
-  username: "liviu",
-  password: "liviu123",
-};
+export const ACCESS_TOKEN_KEY = "cvnsSupabaseAccessToken";
+export const REFRESH_TOKEN_KEY = "cvnsSupabaseRefreshToken";

--- a/src/utils/supabase.js
+++ b/src/utils/supabase.js
@@ -1,0 +1,99 @@
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+function ensureConfig() {
+  if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+    throw new Error(
+      "Supabase environment variables are missing. Please define NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY.",
+    );
+  }
+}
+
+function buildHeaders(accessToken) {
+  const headers = {
+    apikey: SUPABASE_ANON_KEY,
+  };
+
+  if (accessToken) {
+    headers.Authorization = `Bearer ${accessToken}`;
+  }
+
+  return headers;
+}
+
+export async function signInWithEmailPassword(email, password) {
+  ensureConfig();
+
+  const response = await fetch(
+    `${SUPABASE_URL}/auth/v1/token?grant_type=password`,
+    {
+      method: "POST",
+      headers: {
+        ...buildHeaders(),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ email, password }),
+    },
+  );
+
+  const payload = await response.json().catch(() => ({}));
+
+  if (!response.ok) {
+    const message = payload?.error_description || payload?.msg || payload?.message || "Unable to sign in.";
+    throw new Error(message);
+  }
+
+  return payload;
+}
+
+export async function getUser(accessToken) {
+  ensureConfig();
+
+  if (!accessToken) {
+    return null;
+  }
+
+  const response = await fetch(`${SUPABASE_URL}/auth/v1/user`, {
+    method: "GET",
+    headers: buildHeaders(accessToken),
+  });
+
+  if (response.status === 401 || response.status === 403) {
+    return null;
+  }
+
+  const payload = await response.json().catch(() => ({}));
+
+  if (!response.ok) {
+    const message = payload?.message || payload?.error || "Unable to fetch user.";
+    throw new Error(message);
+  }
+
+  return payload;
+}
+
+export async function signOut(accessToken, refreshToken) {
+  ensureConfig();
+
+  if (!accessToken) {
+    return;
+  }
+
+  try {
+    const hasRefreshToken = Boolean(refreshToken);
+    const headers = buildHeaders(accessToken);
+    if (hasRefreshToken) {
+      headers["Content-Type"] = "application/json";
+    }
+    await fetch(`${SUPABASE_URL}/auth/v1/logout`, {
+      method: "POST",
+      headers,
+      body: hasRefreshToken ? JSON.stringify({ refresh_token: refreshToken }) : undefined,
+    });
+  } catch (error) {
+    console.error("Failed to sign out from Supabase:", error);
+  }
+}
+
+// NOTE: Display names must currently be configured directly inside the Supabase dashboard.
+// The automation in this repository does not have network access to update user profiles.


### PR DESCRIPTION
## Summary
- replace the hard-coded demo credentials with Supabase email/password authentication
- persist Supabase access and refresh tokens locally and validate sessions on the dashboard
- document Supabase environment setup and add an example env file for the required keys

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cce5a419f8832c9dbcbc9bc3266627